### PR TITLE
enable python3.5 compatibility and prevent annoying failure

### DIFF
--- a/icstask.py
+++ b/icstask.py
@@ -19,7 +19,7 @@
 from datetime import datetime, time, timedelta, timezone
 from dateutil import rrule
 from json import dumps, loads
-from os.path import basename, expanduser, getmtime, join
+from os.path import basename, expanduser, getmtime, join, exists
 from re import findall
 from socket import getfqdn
 from subprocess import PIPE, run
@@ -49,10 +49,12 @@ class IcsTask:
 
         with self._lock:
             for fname in ['pending.data', 'completed.data']:
-                mtime = getmtime(join(self._data_location, fname))
-                if mtime > self._mtime:
-                    self._mtime = mtime
-                    update = True
+                data_file = join(self._data_location, fname)
+                if exists(data_file):
+                    mtime = getmtime(data_file)
+                    if mtime > self._mtime:
+                        self._mtime = mtime
+                        update = True
 
             if update:
                 self._tasks = {}

--- a/icstask.py
+++ b/icstask.py
@@ -56,7 +56,7 @@ class IcsTask:
 
             if update:
                 self._tasks = {}
-                tasklist = loads(run(['task', 'rc.verbose=nothing', 'rc.hooks=off', f'rc.data.location={self._data_location}', 'export'], stdout=PIPE).stdout.decode('utf-8'))
+                tasklist = loads(run(['task', 'rc.verbose=nothing', 'rc.hooks=off', 'rc.data.location={self._data_location}'.format(**locals()), 'export'], stdout=PIPE).stdout.decode('utf-8'))
                 for task in tasklist:
                     project = task['project'] if 'project' in task else 'unaffiliated'
                     if project not in self._tasks:
@@ -258,7 +258,7 @@ class IcsTask:
 
         json = dumps(task, separators=(',', ':'), sort_keys=True)
         with self._lock:
-            p = run(['task', 'rc.verbose=nothing', 'rc.recurrence.confirmation=no', f'rc.data.location={self._data_location}', 'import', '-'], input=json, encoding='utf-8', stdout=PIPE)
+            p = run(['task', 'rc.verbose=nothing', 'rc.recurrence.confirmation=no', 'rc.data.location={self._data_location}'.format(**locals()), 'import', '-'], input=json, encoding='utf-8', stdout=PIPE)
         uuid = findall('(?:add|mod)  ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}) ', p.stdout)[0]
         self._update()
         return self._gen_uid(uuid)
@@ -305,7 +305,7 @@ class IcsTask:
         """
         uuid = uuid.split('@')[0]
         with self._lock:
-            run(['task', 'rc.verbose=nothing', f'rc.data.location={self._data_location}', 'rc.confirmation=no', uuid, 'delete'])
+            run(['task', 'rc.verbose=nothing', 'rc.data.location={self._data_location}'.format(**locals()), 'rc.confirmation=no', uuid, 'delete'])
 
     def replace_vobject(self, uuid, vtodo, project=None):
         """Update the task with the UID from the vObject
@@ -326,7 +326,7 @@ class IcsTask:
 
         uuid = uuid.split('@')[0]
         with self._lock:
-            run(['task', 'rc.verbose=nothing', f'rc.data.location={self._data_location}', 'rc.confirmation=no', uuid, 'modify', f'project:{basename(to_project)}'])
+            run(['task', 'rc.verbose=nothing', 'rc.data.location={self._data_location}'.format(**locals()), 'rc.confirmation=no', uuid, 'modify', 'project:{}'.format(basename(to_project))])
 
 
 def task2ics():


### PR DESCRIPTION
This pull-request aims at establishing compatibility of the code with python 3.5 by removing the f-strings and replacing them with a suitable `.format` construct.
Also add a check before trying to get the modification time of taskwarrior 'pending.data' and 'completed.data' files.